### PR TITLE
Fix PersistentQueue history filtering

### DIFF
--- a/dreamos/core/persistent_queue.py
+++ b/dreamos/core/persistent_queue.py
@@ -287,11 +287,11 @@ class PersistentQueue:
             queue = self._read_queue()
             queue = [msg for msg in queue if msg.get('to_agent') != agent_id]
             self._write_queue(queue)
-            
+
             # Also clear from message history
             self.message_history = [
-                msg for msg in self.message_history 
-                if msg.get('to_agent') != agent_id
+                msg for msg in self.message_history
+                if msg.get('message', {}).get('to_agent') != agent_id
             ]
             
             # Clear rate limiting counters for this agent
@@ -347,8 +347,8 @@ class PersistentQueue:
         try:
             if agent_id:
                 self.message_history = [
-                    msg for msg in self.message_history 
-                    if msg.get('to_agent') != agent_id
+                    msg for msg in self.message_history
+                    if msg.get('message', {}).get('to_agent') != agent_id
                 ]
                 if agent_id in self.message_counts:
                     del self.message_counts[agent_id]

--- a/tests/core/test_persistent_queue.py
+++ b/tests/core/test_persistent_queue.py
@@ -1,0 +1,49 @@
+import os
+from tempfile import TemporaryDirectory
+from pathlib import Path
+
+from dreamos.core.persistent_queue import PersistentQueue
+from dreamos.core.message import Message
+
+
+def create_queue(tmpdir):
+    queue_file = Path(tmpdir) / "queue.json"
+    return PersistentQueue(queue_file=str(queue_file))
+
+
+def test_clear_agent_removes_queue_and_history():
+    with TemporaryDirectory() as tmpdir:
+        queue = create_queue(tmpdir)
+        queue.set_test_mode(True)
+
+        m1 = Message(from_agent="a", to_agent="agent1", content="hi")
+        m2 = Message(from_agent="a", to_agent="agent2", content="hi")
+        queue.enqueue(m1)
+        queue.enqueue(m2)
+
+        queue.clear_agent("agent1")
+
+        status = queue.get_status()
+        assert all(msg.get("to_agent") != "agent1" for msg in status["messages"])
+
+        history = queue.get_message_history()
+        assert all(msg.to_agent != "agent1" for msg in history)
+
+
+def test_clear_history_only_removes_specified_agent():
+    with TemporaryDirectory() as tmpdir:
+        queue = create_queue(tmpdir)
+        queue.set_test_mode(True)
+
+        m1 = Message(from_agent="a", to_agent="agent1", content="hi")
+        m2 = Message(from_agent="a", to_agent="agent2", content="hi")
+        queue.enqueue(m1)
+        queue.enqueue(m2)
+
+        queue.clear_history("agent1")
+
+        history = queue.get_message_history()
+        assert all(msg.to_agent != "agent1" for msg in history)
+        # Ensure queue still contains both messages
+        status = queue.get_status()
+        assert len(status["messages"]) == 2


### PR DESCRIPTION
## Summary
- fix agent filtering in PersistentQueue history cleanup methods
- add regression tests for queue history handling

## Testing
- `pytest tests/core/test_persistent_queue.py -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_683f894fb0648329bd0d1afdce69e5d0