### PR TITLE
Test debug scaffolding

### DIFF
--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -1,0 +1,22 @@
+"""Minimal stubs for test marker helpers used in conftest."""
+
+def is_claimed_by_agent(item, agent_id=None):
+    return False
+
+def get_claiming_agent(item):
+    return None
+
+def get_claim_issue(item):
+    return None
+
+def agent_claimed(item, agent_id, issue):
+    pass
+
+def agent_fixed(item):
+    pass
+
+def agent_skipped(item):
+    pass
+
+def agent_in_progress(item):
+    pass

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+import shutil
+
+TEST_ROOT = Path(__file__).resolve().parents[1]
+TEST_DATA_DIR = TEST_ROOT / "data"
+TEST_OUTPUT_DIR = TEST_ROOT / "output"
+VOICE_QUEUE_DIR = TEST_ROOT / "voice_queue"
+TEST_CONFIG_DIR = TEST_ROOT / "config"
+TEST_RUNTIME_DIR = TEST_ROOT / "runtime"
+TEST_TEMP_DIR = TEST_ROOT / "temp"
+
+
+def safe_remove(path: Path) -> bool:
+    """Remove a file or directory, ignoring errors."""
+    try:
+        if path.is_dir():
+            shutil.rmtree(path, ignore_errors=True)
+        else:
+            path.unlink(missing_ok=True)
+        return True
+    except Exception:
+        return False
+
+
+def ensure_test_dirs() -> None:
+    """Ensure all common test directories exist."""
+    for d in [TEST_DATA_DIR, TEST_OUTPUT_DIR, VOICE_QUEUE_DIR, TEST_CONFIG_DIR,
+              TEST_RUNTIME_DIR, TEST_TEMP_DIR]:
+        d.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- add fallback implementations when tests are missing dependencies
- provide stub modules for pytest helpers
- include simple helpers for creating test directories

## Testing
- `pytest tests/test_config.py::test_config_defaults -q`

------
https://chatgpt.com/codex/tasks/task_e_683f8a3a24f883298f984c70ae224a22