### PR TITLE
Unify messaging enums and dataclass

### DIFF
--- a/dreamos/core/__init__.py
+++ b/dreamos/core/__init__.py
@@ -12,7 +12,7 @@ from . import messaging
 from . import persistent_queue
 from . import system_init
 from .cell_phone import CellPhone, send_message
-from .messaging.types import Message, MessageMode
+from .messaging.common import Message, MessageMode, MessagePriority
 from .persistent_queue import PersistentQueue
 
 __all__ = [
@@ -26,6 +26,7 @@ __all__ = [
     'CellPhone',
     'Message',
     'MessageMode',
+    'MessagePriority',
     'PersistentQueue',
     'send_message'
 ]

--- a/dreamos/core/agent_control/agent_operations.py
+++ b/dreamos/core/agent_control/agent_operations.py
@@ -9,7 +9,7 @@ from typing import Union, List, Optional, Dict, Any
 from pathlib import Path
 
 from ..messaging.message_processor import MessageProcessor
-from ..messaging.types import MessageMode
+from ..messaging.common import MessageMode
 from ..cell_phone import CellPhone
 from .ui_automation import UIAutomation
 

--- a/dreamos/core/agent_control/controller.py
+++ b/dreamos/core/agent_control/controller.py
@@ -16,7 +16,7 @@ from .agent_operations import AgentOperations
 from .ui_automation import UIAutomation
 from ..messaging.message_processor import MessageProcessor
 from ..cell_phone import CellPhone
-from ..messaging.types import Message, MessageMode
+from ..messaging.common import Message, MessageMode
 from ..shared import CoordinateManager
 
 logger = logging.getLogger('agent_control.controller')

--- a/dreamos/core/agent_interface.py
+++ b/dreamos/core/agent_interface.py
@@ -8,7 +8,7 @@ import logging
 from typing import Dict, List, Optional, Any
 from pathlib import Path
 from .cell_phone import CellPhone
-from .messaging.types import MessageMode
+from .messaging.common import MessageMode
 from .messaging.agent_bus import AgentBus, MessagePriority
 
 logger = logging.getLogger('discord_bot.agent_interface')

--- a/dreamos/core/ai/llm_agent.py
+++ b/dreamos/core/ai/llm_agent.py
@@ -8,7 +8,7 @@ import asyncio
 from typing import Dict, Any, Optional, List
 from datetime import datetime
 from ..messaging.unified_message_system import UnifiedMessageSystem
-from ..messaging.message import Message, MessageMode, MessagePriority
+from ..messaging.common import Message, MessageMode, MessagePriority
 from .chatgpt_bridge import ChatGPTBridge
 
 class LLMAgent:

--- a/dreamos/core/cell_phone.py
+++ b/dreamos/core/cell_phone.py
@@ -12,7 +12,7 @@ from typing import Dict, List, Optional, Any
 from datetime import datetime
 from pathlib import Path
 from .persistent_queue import PersistentQueue
-from .messaging.types import Message, MessageMode
+from .messaging.common import Message, MessageMode
 
 logger = logging.getLogger('cell_phone')
 

--- a/dreamos/core/cli.py
+++ b/dreamos/core/cli.py
@@ -16,10 +16,10 @@ if __name__ == "__main__":
     project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     sys.path.insert(0, project_root)
     from dreamos.core.message_processor import MessageProcessor
-    from dreamos.core.messaging.types import Message, MessageMode
+    from dreamos.core.messaging.common import Message, MessageMode
 else:
     from .message_processor import MessageProcessor
-    from .messaging.types import Message, MessageMode
+    from .messaging.common import Message, MessageMode
 
 # Version information
 __version__ = "1.0.0"

--- a/dreamos/core/message_loop.py
+++ b/dreamos/core/message_loop.py
@@ -3,7 +3,7 @@ import logging
 from typing import Optional, Callable, Awaitable
 from datetime import datetime
 
-from .message import Message
+from .messaging.common import Message
 
 logger = logging.getLogger(__name__)
 

--- a/dreamos/core/message_processor.py
+++ b/dreamos/core/message_processor.py
@@ -8,7 +8,7 @@ import logging
 from typing import Dict, List, Optional, Any
 from datetime import datetime
 from .cell_phone import CellPhone
-from .messaging.types import Message, MessageMode
+from .messaging.common import Message, MessageMode
 from .cursor_controller import CursorController
 from .coordinate_manager import CoordinateManager
 import pyautogui

--- a/dreamos/core/messaging/__init__.py
+++ b/dreamos/core/messaging/__init__.py
@@ -2,13 +2,14 @@
 Messaging module for Dream.OS.
 """
 
-from .types import Message, MessageMode
+from .common import Message, MessageMode, MessagePriority
 from dreamos.core.cell_phone import CellPhone
 from dreamos.core.message_processor import MessageProcessor
 
 __all__ = [
     'Message',
     'MessageMode',
+    'MessagePriority',
     'CellPhone',
     'MessageProcessor'
 ]

--- a/dreamos/core/messaging/agent_bus.py
+++ b/dreamos/core/messaging/agent_bus.py
@@ -18,7 +18,7 @@ from queue import PriorityQueue
 from pathlib import Path
 import json
 
-from .message import Message, MessageMode
+from .common import Message, MessageMode
 
 logger = logging.getLogger(__name__)
 

--- a/dreamos/core/messaging/common.py
+++ b/dreamos/core/messaging/common.py
@@ -1,0 +1,116 @@
+"""Common messaging types for Dream.OS."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Dict, Any, Optional
+
+
+class MessageMode(Enum):
+    """Message modes for different types of communication."""
+    RESUME = "[RESUME]"
+    SYNC = "[SYNC]"
+    VERIFY = "[VERIFY]"
+    REPAIR = "[REPAIR]"
+    BACKUP = "[BACKUP]"
+    RESTORE = "[RESTORE]"
+    CLEANUP = "[CLEANUP]"
+    CAPTAIN = "[CAPTAIN]"
+    TASK = "[TASK]"
+    INTEGRATE = "[INTEGRATE]"
+    NORMAL = "[NORMAL]"
+    PRIORITY = "[PRIORITY]"
+    BULK = "[BULK]"
+    SELF_TEST = "[SELF_TEST]"
+    PROMPT = "[PROMPT]"
+    DEVLOG = "[DEVLOG]"
+    SYSTEM = "[SYSTEM]"
+    COMMAND = "[COMMAND]"
+
+
+class MessagePriority(Enum):
+    """Message priority levels."""
+    LOWEST = 0
+    LOW = 1
+    NORMAL = 2
+    HIGH = 3
+    HIGHEST = 4
+    CRITICAL = 5
+
+
+@dataclass
+class Message:
+    """Represents a message in the Dream.OS system."""
+    from_agent: str
+    to_agent: str
+    content: str
+    mode: MessageMode = MessageMode.NORMAL
+    priority: MessagePriority = MessagePriority.NORMAL
+    message_id: Optional[str] = None
+    timestamp: Optional[datetime] = None
+    status: str = "queued"
+    metadata: Optional[Dict[str, Any]] = None
+
+    def __post_init__(self) -> None:
+        if self.timestamp is None:
+            self.timestamp = datetime.now()
+        if self.metadata is None:
+            self.metadata = {}
+        if self.message_id is None:
+            self.message_id = f"{self.timestamp.isoformat()}-{self.from_agent}-{self.to_agent}"
+
+    def format_content(self) -> str:
+        """Format message content with mode prefix."""
+        return f"{self.mode.value} {self.content}"
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert message to a dictionary."""
+        return {
+            "message_id": self.message_id,
+            "from_agent": self.from_agent,
+            "to_agent": self.to_agent,
+            "content": self.content,
+            "mode": self.mode.value,
+            "priority": self.priority.value,
+            "timestamp": self.timestamp.isoformat(),
+            "status": self.status,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Message":
+        mode_val = data.get("mode", MessageMode.NORMAL.value)
+        if mode_val in MessageMode.__members__:
+            mode = MessageMode[mode_val]
+        else:
+            mode = MessageMode(mode_val)
+
+        prio_val = data.get("priority", MessagePriority.NORMAL.value)
+        if isinstance(prio_val, str) and prio_val in MessagePriority.__members__:
+            priority = MessagePriority[prio_val]
+        else:
+            priority = MessagePriority(prio_val)
+
+        return cls(
+            from_agent=data["from_agent"],
+            to_agent=data["to_agent"],
+            content=data["content"],
+            mode=mode,
+            priority=priority,
+            message_id=data.get("message_id"),
+            timestamp=datetime.fromisoformat(data["timestamp"]),
+            status=data.get("status", "queued"),
+            metadata=data.get("metadata", {}),
+        )
+
+    def validate(self) -> bool:
+        try:
+            if not self.content:
+                raise ValueError("Message content cannot be empty")
+            if not self.from_agent or not self.to_agent:
+                raise ValueError("Both from_agent and to_agent must be specified")
+            if not isinstance(self.priority, MessagePriority):
+                raise ValueError("Invalid message priority")
+            return True
+        except Exception:
+            return False

--- a/dreamos/core/messaging/history.py
+++ b/dreamos/core/messaging/history.py
@@ -9,7 +9,8 @@ import logging
 from pathlib import Path
 from typing import List, Dict, Any, Optional
 from datetime import datetime
-from .unified_message_system import Message, MessageHistory
+from .common import Message
+from .unified_message_system import MessageHistory
 
 logger = logging.getLogger('dreamos.messaging.history')
 

--- a/dreamos/core/messaging/message.py
+++ b/dreamos/core/messaging/message.py
@@ -5,102 +5,12 @@ Defines core message types and structures for the Dream.OS messaging system.
 """
 
 import logging
-from dataclasses import dataclass
-from datetime import datetime
-from enum import Enum
-from typing import Optional, Dict, Any
+from typing import Dict, Any
+
+from .common import Message, MessageMode, MessagePriority
 
 logger = logging.getLogger('messaging.message')
 
-class MessageMode(Enum):
-    """Message delivery modes."""
-    RESUME = "[RESUME]"
-    SYNC = "[SYNC]"
-    VERIFY = "[VERIFY]"
-    REPAIR = "[REPAIR]"
-    BACKUP = "[BACKUP]"
-    RESTORE = "[RESTORE]"
-    CLEANUP = "[CLEANUP]"
-    CAPTAIN = "[CAPTAIN]"
-    TASK = "[TASK]"
-    INTEGRATE = "[INTEGRATE]"
-    NORMAL = "[NORMAL]"  # Changed from empty string to include brackets
-    PRIORITY = "[PRIORITY]"
-    BULK = "[BULK]"
-    SELF_TEST = "[SELF_TEST]"  # For self-test protocol messages
-    PROMPT = "[PROMPT]"  # For agent prompts
-    DEVLOG = "[DEVLOG]"  # For development logs
-    SYSTEM = "[SYSTEM]"  # For system commands
 
-class MessagePriority(Enum):
-    """Message priority levels."""
-    LOWEST = 0
-    LOW = 1
-    NORMAL = 2
-    HIGH = 3
-    HIGHEST = 4
-    CRITICAL = 5
-
-@dataclass
-class Message:
-    """Represents a message in the Dream.OS system."""
-    from_agent: str
-    to_agent: str
-    content: str
-    mode: MessageMode = MessageMode.NORMAL
-    priority: int = 0
-    timestamp: datetime = None
-    status: str = "queued"
-    metadata: Dict[str, Any] = None
-    
-    def __post_init__(self):
-        """Initialize default values."""
-        if self.timestamp is None:
-            self.timestamp = datetime.now()
-        if self.metadata is None:
-            self.metadata = {}
-            
-    def format_content(self) -> str:
-        """Format message content with mode prefix."""
-        return f"{self.mode.value} {self.content}"
-        
-    def to_dict(self) -> Dict[str, Any]:
-        """Convert message to dictionary format (store original content, not formatted)."""
-        return {
-            "from_agent": self.from_agent,
-            "to_agent": self.to_agent,
-            "content": self.content,  # store original content only
-            "mode": self.mode.name,
-            "priority": self.priority,
-            "timestamp": self.timestamp.isoformat(),
-            "status": self.status,
-            "metadata": self.metadata
-        }
-        
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'Message':
-        """Create message from dictionary format."""
-        return cls(
-            from_agent=data["from_agent"],
-            to_agent=data["to_agent"],
-            content=data["content"],
-            mode=MessageMode[data["mode"]],
-            priority=data["priority"],
-            timestamp=datetime.fromisoformat(data["timestamp"]),
-            status=data["status"],
-            metadata=data.get("metadata", {})
-        )
-        
-    def validate(self) -> bool:
-        """Validate message fields."""
-        try:
-            if not self.content:
-                raise ValueError("Message content cannot be empty")
-            if not 0 <= self.priority <= 5:
-                raise ValueError("Priority must be between 0 and 5")
-            if not self.from_agent or not self.to_agent:
-                raise ValueError("Both from_agent and to_agent must be specified")
-            return True
-        except Exception as e:
-            logger.error(f"Message validation failed: {e}")
-            return False 
+# Re-export for backward compatibility
+__all__ = ["Message", "MessageMode", "MessagePriority"]

--- a/dreamos/core/messaging/message_processor.py
+++ b/dreamos/core/messaging/message_processor.py
@@ -11,25 +11,10 @@ import hashlib
 from typing import Dict, List, Optional, Any, Tuple
 from queue import PriorityQueue
 from datetime import datetime
-from enum import Enum
+from .common import MessageMode
 
 logger = logging.getLogger('message_processor')
 
-class MessageMode(Enum):
-    """Message delivery modes."""
-    RESUME = "[RESUME]"
-    SYNC = "[SYNC]"
-    VERIFY = "[VERIFY]"
-    REPAIR = "[REPAIR]"
-    BACKUP = "[BACKUP]"
-    RESTORE = "[RESTORE]"
-    CLEANUP = "[CLEANUP]"
-    CAPTAIN = "[CAPTAIN]"
-    TASK = "[TASK]"
-    INTEGRATE = "[INTEGRATE]"
-    NORMAL = ""  # No additional tags
-    PRIORITY = "priority"
-    BULK = "bulk"
 
 class MessageProcessor:
     """Handles message processing and delivery for the cell phone interface."""

--- a/dreamos/core/messaging/message_system.py
+++ b/dreamos/core/messaging/message_system.py
@@ -11,29 +11,10 @@ from typing import List, Dict, Any, Optional
 from datetime import datetime
 from dataclasses import dataclass, asdict
 from abc import ABC, abstractmethod
-from enum import Enum
+
+from .common import MessageMode
 
 logger = logging.getLogger('dreamos.messaging')
-
-class MessageMode(Enum):
-    """Message modes for different types of communication."""
-    RESUME = "[RESUME]"
-    SYNC = "[SYNC]"
-    VERIFY = "[VERIFY]"
-    REPAIR = "[REPAIR]"
-    BACKUP = "[BACKUP]"
-    RESTORE = "[RESTORE]"
-    CLEANUP = "[CLEANUP]"
-    CAPTAIN = "[CAPTAIN]"
-    TASK = "[TASK]"
-    INTEGRATE = "[INTEGRATE]"
-    NORMAL = "[NORMAL]"
-    PRIORITY = "[PRIORITY]"
-    BULK = "[BULK]"
-    SELF_TEST = "[SELF_TEST]"
-    PROMPT = "[PROMPT]"
-    DEVLOG = "[DEVLOG]"
-    SYSTEM = "[SYSTEM]"
 
 @dataclass
 class MessageRecord:

--- a/dreamos/core/messaging/queue.py
+++ b/dreamos/core/messaging/queue.py
@@ -11,7 +11,8 @@ from pathlib import Path
 from typing import List, Dict, Any, Optional
 from datetime import datetime
 from queue import PriorityQueue
-from .unified_message_system import Message, MessageQueue, MessagePriority
+from .common import Message, MessagePriority
+from .unified_message_system import MessageQueue
 
 logger = logging.getLogger('dreamos.messaging.queue')
 

--- a/dreamos/core/messaging/router.py
+++ b/dreamos/core/messaging/router.py
@@ -7,7 +7,8 @@ Provides message routing functionality for the unified message system.
 import logging
 import re
 from typing import Dict, Set, Callable, Pattern, Optional
-from .unified_message_system import Message, MessageRouter, MessageMode
+from .common import Message, MessageMode
+from .unified_message_system import MessageRouter
 
 logger = logging.getLogger('dreamos.messaging.router')
 

--- a/dreamos/core/messaging/types.py
+++ b/dreamos/core/messaging/types.py
@@ -4,89 +4,10 @@ Shared message types and enums.
 This module contains shared types used across the messaging system.
 """
 
-from dataclasses import dataclass
-from datetime import datetime
-from enum import Enum
 from typing import Dict, Any
 
-class MessageMode(Enum):
-    """Message modes for different types of communication."""
-    RESUME = "[RESUME]"
-    SYNC = "[SYNC]"
-    VERIFY = "[VERIFY]"
-    REPAIR = "[REPAIR]"
-    BACKUP = "[BACKUP]"
-    RESTORE = "[RESTORE]"
-    CLEANUP = "[CLEANUP]"
-    CAPTAIN = "[CAPTAIN]"
-    TASK = "[TASK]"
-    INTEGRATE = "[INTEGRATE]"
-    NORMAL = ""  # No additional tags
-    PRIORITY = "priority"
-    BULK = "bulk"
-    SELF_TEST = "[SELF_TEST]"  # For self-test protocol messages
+from .common import Message, MessageMode, MessagePriority
 
-@dataclass
-class Message:
-    """Represents a message in the Dream.OS system."""
-    from_agent: str
-    to_agent: str
-    content: str
-    mode: MessageMode = MessageMode.NORMAL
-    priority: int = 0
-    timestamp: datetime = None
-    status: str = "queued"
-    metadata: Dict[str, Any] = None
-    
-    def __post_init__(self):
-        """Initialize default values."""
-        if self.timestamp is None:
-            self.timestamp = datetime.now()
-        if self.metadata is None:
-            self.metadata = {}
-            
-    def format_content(self) -> str:
-        """Format message content with mode prefix."""
-        if self.mode == MessageMode.NORMAL:
-            return self.content
-        return f"{self.mode.value} {self.content}"
-        
-    def to_dict(self) -> Dict[str, Any]:
-        """Convert message to dictionary format."""
-        return {
-            "from_agent": self.from_agent,
-            "to_agent": self.to_agent,
-            "content": self.format_content(),
-            "mode": self.mode.name,
-            "priority": self.priority,
-            "timestamp": self.timestamp.isoformat(),
-            "status": self.status,
-            "metadata": self.metadata
-        }
-        
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'Message':
-        """Create message from dictionary format."""
-        return cls(
-            from_agent=data["from_agent"],
-            to_agent=data["to_agent"],
-            content=data["content"],
-            mode=MessageMode[data["mode"]],
-            priority=data["priority"],
-            timestamp=datetime.fromisoformat(data["timestamp"]),
-            status=data["status"],
-            metadata=data.get("metadata", {})
-        )
-        
-    def validate(self) -> bool:
-        """Validate message fields."""
-        try:
-            if not self.content:
-                raise ValueError("Message content cannot be empty")
-            if not 0 <= self.priority <= 5:
-                raise ValueError("Priority must be between 0 and 5")
-            if not self.from_agent or not self.to_agent:
-                raise ValueError("Both from_agent and to_agent must be specified")
-            return True
-        except Exception as e:
-            return False 
+
+# Re-export for backward compatibility
+__all__ = ["Message", "MessageMode", "MessagePriority"]

--- a/dreamos/core/messaging/ui.py
+++ b/dreamos/core/messaging/ui.py
@@ -9,7 +9,7 @@ import time
 from typing import Optional, Dict, Any
 import pyautogui
 
-from .message import Message, MessageMode
+from .common import Message, MessageMode
 from .processor import MessageProcessor
 
 logger = logging.getLogger('messaging.ui')

--- a/dreamos/core/messaging/unified_message_system.py
+++ b/dreamos/core/messaging/unified_message_system.py
@@ -18,84 +18,13 @@ from typing import List, Dict, Any, Optional, Set, Callable, Pattern
 from datetime import datetime
 from dataclasses import dataclass, asdict
 from abc import ABC, abstractmethod
-from enum import Enum
+
+from .common import Message, MessageMode, MessagePriority
 from queue import PriorityQueue
 import re
 from uuid import uuid4
 
 logger = logging.getLogger('dreamos.messaging')
-
-class MessageMode(Enum):
-    """Message modes for different types of communication."""
-    RESUME = "[RESUME]"
-    SYNC = "[SYNC]"
-    VERIFY = "[VERIFY]"
-    REPAIR = "[REPAIR]"
-    BACKUP = "[BACKUP]"
-    RESTORE = "[RESTORE]"
-    CLEANUP = "[CLEANUP]"
-    CAPTAIN = "[CAPTAIN]"
-    TASK = "[TASK]"
-    INTEGRATE = "[INTEGRATE]"
-    NORMAL = "[NORMAL]"
-    PRIORITY = "[PRIORITY]"
-    BULK = "[BULK]"
-    SELF_TEST = "[SELF_TEST]"
-    PROMPT = "[PROMPT]"
-    DEVLOG = "[DEVLOG]"
-    SYSTEM = "[SYSTEM]"
-    COMMAND = "[COMMAND]"
-
-class MessagePriority(Enum):
-    """Message priority levels."""
-    LOWEST = 0
-    LOW = 1
-    NORMAL = 2
-    HIGH = 3
-    HIGHEST = 4
-    CRITICAL = 5
-
-@dataclass
-class Message:
-    """Unified message structure."""
-    message_id: str
-    sender_id: str
-    recipient_id: str
-    content: str
-    mode: MessageMode
-    priority: MessagePriority
-    timestamp: datetime
-    metadata: Dict[str, Any]
-    status: str = "queued"
-
-    def to_dict(self) -> Dict[str, Any]:
-        """Convert to dictionary for storage."""
-        return {
-            "message_id": self.message_id,
-            "sender_id": self.sender_id,
-            "recipient_id": self.recipient_id,
-            "content": self.content,
-            "mode": self.mode.value,
-            "priority": self.priority.value,
-            "timestamp": self.timestamp.isoformat(),
-            "metadata": self.metadata,
-            "status": self.status
-        }
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'Message':
-        """Create from dictionary."""
-        return cls(
-            message_id=data["message_id"],
-            sender_id=data["sender_id"],
-            recipient_id=data["recipient_id"],
-            content=data["content"],
-            mode=MessageMode(data["mode"]),
-            priority=MessagePriority(data["priority"]),
-            timestamp=datetime.fromisoformat(data["timestamp"]),
-            metadata=data["metadata"],
-            status=data["status"]
-        )
 
 class MessageQueue(ABC):
     """Abstract base class for message queue implementations."""
@@ -157,9 +86,9 @@ class SimpleQueue(MessageQueue):
     
     async def enqueue(self, message: Message) -> bool:
         """Add message to queue."""
-        if message.recipient_id not in self._messages:
-            self._messages[message.recipient_id] = []
-        self._messages[message.recipient_id].append(message)
+        if message.to_agent not in self._messages:
+            self._messages[message.to_agent] = []
+        self._messages[message.to_agent].append(message)
         return True
     
     async def get_messages(self, agent_id: str) -> List[Message]:
@@ -191,7 +120,7 @@ class SimpleHistory(MessageHistory):
         """Get message history with optional filtering."""
         filtered = self._history
         if agent_id:
-            filtered = [m for m in filtered if m.recipient_id == agent_id]
+            filtered = [m for m in filtered if m.to_agent == agent_id]
         if start_time:
             filtered = [m for m in filtered if m.timestamp >= start_time]
         if end_time:
@@ -286,8 +215,8 @@ class UnifiedMessageSystem:
             # Create message
             message = Message(
                 message_id=str(uuid4()),
-                sender_id=from_agent,
-                recipient_id=to_agent,
+                from_agent=from_agent,
+                to_agent=to_agent,
                 content=content,
                 mode=mode,
                 priority=priority,
@@ -416,8 +345,8 @@ class UnifiedMessageSystem:
             message: Message to notify about
         """
         # Notify direct subscribers
-        if message.recipient_id in self._subscribers:
-            for handler in self._subscribers[message.recipient_id]:
+        if message.to_agent in self._subscribers:
+            for handler in self._subscribers[message.to_agent]:
                 try:
                     await handler(message)
                 except Exception as e:
@@ -425,7 +354,7 @@ class UnifiedMessageSystem:
         
         # Notify pattern subscribers
         for pattern, handlers in self._pattern_subscribers.items():
-            if pattern.match(message.recipient_id):
+            if pattern.match(message.to_agent):
                 for handler in handlers:
                     try:
                         await handler(message)

--- a/dreamos/core/persistent_queue.py
+++ b/dreamos/core/persistent_queue.py
@@ -11,7 +11,7 @@ import logging
 from pathlib import Path
 from typing import Dict, List, Optional, Any, Union
 from datetime import datetime
-from dreamos.core.messaging.message import Message  # Import Message for type checking
+from dreamos.core.messaging.common import Message  # Import Message for type checking
 
 logger = logging.getLogger('persistent_queue')
 


### PR DESCRIPTION
## Summary
- centralize message types in `dreamos/core/messaging/common.py`
- update all messaging modules to import from the new common module
- adjust unified message system to use new fields
- clean up duplicate definitions across the codebase

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_e_683f8ec614b88329bedc608af54257d3