### PR TITLE
Fix missing test utils import

### DIFF
--- a/tests/helpers/discord_test_utils.py
+++ b/tests/helpers/discord_test_utils.py
@@ -1,5 +1,5 @@
-from .core.test_utils import (
+from tests.utils import (
     MockMessage, MockMember, MockChannel, MockGuild,
     MockContext, MockBot, create_mock_embed, run_async_test,
-    mock_discord_file
-) 
+    mock_discord_file,
+)


### PR DESCRIPTION
## Summary
- fix import path in `tests/helpers/discord_test_utils.py`

## Testing
- `python3 - <<'PY'
import importlib
module = importlib.import_module('tests.helpers.discord_test_utils')
print('OK', module)
PY
`
- `pytest tests/helpers -q`

------
https://chatgpt.com/codex/tasks/task_e_683f979da24c83299bee36f80bcd8842