### PR TITLE
Modernize devlog manager tests

### DIFF
--- a/tests/agent_control/test_devlog_manager.py
+++ b/tests/agent_control/test_devlog_manager.py
@@ -1,4 +1,3 @@
-import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock
 import sys
@@ -72,25 +71,27 @@ spec.loader.exec_module(devlog_module)
 DevLogManager = devlog_module.DevLogManager
 
 
-def test_add_and_get_log(tmp_path: Path):
+@pytest.mark.asyncio
+async def test_add_and_get_log(tmp_path: Path):
     manager = DevLogManager(runtime_dir=tmp_path)
     manager._notify_discord = AsyncMock()
 
-    result = asyncio.run(manager.add_entry("agent1", "hello world"))
+    result = await manager.add_entry("agent1", "hello world")
     assert result
 
-    content = asyncio.run(manager.get_log("agent1"))
+    content = await manager.get_log("agent1")
     assert "hello world" in content
     manager._notify_discord.assert_awaited()
 
 
-def test_clear_log(tmp_path: Path):
+@pytest.mark.asyncio
+async def test_clear_log(tmp_path: Path):
     manager = DevLogManager(runtime_dir=tmp_path)
     manager._notify_discord = AsyncMock()
 
-    asyncio.run(manager.add_entry("agent1", "something"))
-    cleared = asyncio.run(manager.clear_log("agent1"))
+    await manager.add_entry("agent1", "something")
+    cleared = await manager.clear_log("agent1")
     assert cleared
 
-    content = asyncio.run(manager.get_log("agent1"))
+    content = await manager.get_log("agent1")
     assert "Log cleared" in content


### PR DESCRIPTION
## Summary
- update devlog manager tests to use `pytest-asyncio`
- run manager methods with `await` instead of `asyncio.run`

## Testing
- `pytest tests/agent_control/test_devlog_manager.py -q`
- `pytest -q` *(fails: Missing required browser configuration keys)*

------
https://chatgpt.com/codex/tasks/task_e_683fa1f70af08329a669e8b9de3da0f3