### PR TITLE
Resolve merge conflicts for messaging refactor

### DIFF
--- a/dreamos/core/message_loop.py
+++ b/dreamos/core/message_loop.py
@@ -3,7 +3,7 @@ import logging
 from typing import Optional, Callable, Awaitable
 from datetime import datetime
 
-from .message import Message
+from .messaging.common import Message
 
 logger = logging.getLogger(__name__)
 

--- a/dreamos/core/messaging/history.py
+++ b/dreamos/core/messaging/history.py
@@ -9,7 +9,8 @@ import logging
 from pathlib import Path
 from typing import List, Dict, Any, Optional
 from datetime import datetime
-from .unified_message_system import Message, MessageHistory
+from .common import Message
+from .unified_message_system import MessageHistory
 
 logger = logging.getLogger('dreamos.messaging.history')
 

--- a/dreamos/core/messaging/router.py
+++ b/dreamos/core/messaging/router.py
@@ -7,7 +7,8 @@ Provides message routing functionality for the unified message system.
 import logging
 import re
 from typing import Dict, Set, Callable, Pattern, Optional
-from .unified_message_system import Message, MessageRouter, MessageMode
+from .common import Message, MessageMode
+from .unified_message_system import MessageRouter
 
 logger = logging.getLogger('dreamos.messaging.router')
 

--- a/dreamos/core/messaging/ui.py
+++ b/dreamos/core/messaging/ui.py
@@ -9,7 +9,7 @@ import time
 from typing import Optional, Dict, Any
 import pyautogui
 
-from .message import Message, MessageMode
+from .common import Message, MessageMode
 from .processor import MessageProcessor
 
 logger = logging.getLogger('messaging.ui')


### PR DESCRIPTION
## Summary
- merge latest master into the shared-enums refactor branch
- maintain legacy `Message` compatibility in `PersistentQueue`
- update messaging modules to import unified definitions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_e_683f9bd3a57c83298b107fd67b3a58f4