### PR TITLE
Improve queue lock

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,8 @@ edge-tts>=6.1.9
 aiohttp>=3.9.1
 uiautomation>=2.0.18  # For Windows UI automation in tests
 
+filelock>=3.12.0
+
 geopy>=2.4.1
 requests>=2.31.0
 pytest>=8.0.0


### PR DESCRIPTION
## Summary
- optimize PersistentQueue lock handling using FileLock
- ensure priority stored as enum name
- add `filelock` as a dependency

## Testing
- `pytest -q tests/core/test_persistent_queue.py`

------
https://chatgpt.com/codex/tasks/task_e_68406b4c949c8329afbcccb1573393e3