### PR TITLE
Fix tests by resetting log configuration

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -24,10 +24,10 @@ def run_test(test_path, test_name=None):
     return result
 
 if __name__ == '__main__':
-    # Get test path from command line
-    test_path = sys.argv[1] if len(sys.argv) > 1 else 'tests/test_log_manager.py'
+    # Get test path from command line or default to the entire suite
+    test_path = sys.argv[1] if len(sys.argv) > 1 else 'tests'
     test_name = sys.argv[2] if len(sys.argv) > 2 else None
-    
-    # Run the test
+
+    # Run the tests and exit with the result code
     result = run_test(test_path, test_name)
-    sys.exit(result) 
+    sys.exit(result)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -270,7 +270,8 @@ def setup_logging():
     """Configure logging for all tests."""
     logging.basicConfig(
         level=logging.INFO,
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        force=True
     )
     yield
 

--- a/tests/messaging/test_unified_message_system.py
+++ b/tests/messaging/test_unified_message_system.py
@@ -16,6 +16,7 @@ MessagePriority = ums_module.MessagePriority
 
 
 def test_send_and_receive(tmp_path):
+    UnifiedMessageSystem._instance = None
     ums = UnifiedMessageSystem(runtime_dir=tmp_path)
     asyncio.run(ums.send(
         to_agent="Agent-Test",


### PR DESCRIPTION
## Summary
- reset message system singleton in test
- force logging configuration for clean handlers
- use tests as default path in `run_tests.py`

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_684074b98b408329b5100cf15493919e