### PR TITLE
Fix test stability

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-pytest>=7.0.0
+pytest>=8.0.0
 pytest-cov>=4.0.0
 pytest-mock>=3.10.0
 pytest-timeout>=2.1.0
@@ -10,9 +10,3 @@ pytest-env>=1.0.0
 pytest-randomly>=3.12.0
 pytest-repeat>=0.9.1
 pytest-rerunfailures>=11.1.2
-pytest-sugar>=0.9.7
-pytest-xdist>=3.0.0
-pytest-timeout>=2.1.0
-pytest-mock>=3.10.0
-pytest-cov>=4.0.0
-pytest>=7.0.0 

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,33 +1,27 @@
 import pytest
 import sys
-import os
-import time
+import shutil
+from pathlib import Path
 
-def run_test(test_path, test_name=None):
-    """Run a specific test with proper cleanup and timeout."""
-    # Clear any existing test cache
-    pytest.main(['--cache-clear'])
-    
-    # Build test path
+
+def run_test(test_path="tests", test_name=None):
+    """Run tests with a timeout and short traceback."""
+    cache_dir = Path(".pytest_cache")
+    if cache_dir.exists():
+        shutil.rmtree(cache_dir)
     if test_name:
         test_path = f"{test_path}::{test_name}"
-    
-    # Run test with timeout and short traceback
-    result = pytest.main([
+    return pytest.main([
         test_path,
-        '-v',
-        '--tb=short',
-        '--timeout=30',
-        '-xvs'
+        "-v",
+        "--tb=short",
+        "--timeout=30",
+        "-xvs"
     ])
-    
-    return result
 
-if __name__ == '__main__':
-    # Get test path from command line
-    test_path = sys.argv[1] if len(sys.argv) > 1 else 'tests/test_log_manager.py'
-    test_name = sys.argv[2] if len(sys.argv) > 2 else None
-    
-    # Run the test
-    result = run_test(test_path, test_name)
-    sys.exit(result) 
+
+if __name__ == "__main__":
+    path = sys.argv[1] if len(sys.argv) > 1 else "tests"
+    name = sys.argv[2] if len(sys.argv) > 2 else None
+    result = run_test(path, name)
+    sys.exit(result)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -268,11 +268,17 @@ def clean_test_dirs() -> Generator[None, None, None]:
 @pytest.fixture(autouse=True)
 def setup_logging():
     """Configure logging for all tests."""
+    logging.shutdown()
+    for handler in logging.root.handlers[:]:
+        logging.root.removeHandler(handler)
     logging.basicConfig(
         level=logging.INFO,
         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
     )
     yield
+    logging.shutdown()
+    for handler in logging.root.handlers[:]:
+        logging.root.removeHandler(handler)
 
 @pytest.fixture(autouse=True)
 def mock_pyautogui() -> Generator[None, None, None]:


### PR DESCRIPTION
## Summary
- clean pytest cache without executing tests twice
- reset logging handlers between tests
- simplify test requirements

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_684074bf32208329b372b36a71e3ff82