### PR TITLE
Add JSON config loader

### DIFF
--- a/social/utils/__init__.py
+++ b/social/utils/__init__.py
@@ -8,10 +8,12 @@ from .log_types import RotationConfig
 from .log_level import LogLevel
 from .log_config import LogConfig
 from .log_rotator import LogRotator
+from .json_settings import JSONConfig
 
 __all__ = [
     'RotationConfig',
     'LogLevel',
     'LogConfig',
-    'LogRotator'
-] 
+    'LogRotator',
+    'JSONConfig'
+]

--- a/social/utils/json_settings.py
+++ b/social/utils/json_settings.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+"""JSON configuration management utilities."""
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict
+
+
+@dataclass
+class ConfigNode:
+    """Data holder that provides attribute access like a dotmap."""
+
+    data: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for key, value in list(self.data.items()):
+            if isinstance(value, dict):
+                self.data[key] = ConfigNode(value)
+
+    def __getattr__(self, item: str) -> Any:
+        if item in self.data:
+            return self.data[item]
+        raise AttributeError(item)
+
+    def __iter__(self):
+        return iter(self.data)
+
+    def items(self):
+        return self.data.items()
+
+    def values(self):
+        return self.data.values()
+
+    def __getitem__(self, item: str) -> Any:
+        return self.data[item]
+
+    def as_dict(self) -> Dict[str, Any]:
+        def convert(val: Any) -> Any:
+            if isinstance(val, ConfigNode):
+                return {k: convert(v) for k, v in val.data.items()}
+            return val
+
+        return {k: convert(v) for k, v in self.data.items()}
+
+
+class JSONConfig(ConfigNode):
+    """Load configuration from a JSON file."""
+
+    def __init__(self, path: str | Path) -> None:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        super().__init__(data)
+        self.path = Path(path)
+
+    def reload(self) -> None:
+        """Reload configuration from disk."""
+        with open(self.path, "r", encoding="utf-8") as f:
+            self.data = json.load(f)
+        self.__post_init__()

--- a/tests/social/test_json_config.py
+++ b/tests/social/test_json_config.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+
+from social.utils import JSONConfig
+from social.utils.log_manager import LogManager, LogConfig
+
+
+def test_json_config_access(tmp_path):
+    data = {
+        "logging": {
+            "log_dir": str(tmp_path / "logs"),
+            "level": "INFO"
+        },
+        "backend": {
+            "url": "http://localhost"
+        }
+    }
+    cfg_path = tmp_path / "config.json"
+    with open(cfg_path, "w") as f:
+        json.dump(data, f)
+
+    cfg = JSONConfig(cfg_path)
+
+    assert cfg.logging.log_dir == str(tmp_path / "logs")
+    assert cfg.backend.url == "http://localhost"
+    assert cfg.as_dict()["logging"]["level"] == "INFO"
+
+
+def test_json_config_integration_with_log_manager(tmp_path):
+    log_dir = tmp_path / "logs"
+    cfg_path = tmp_path / "config.json"
+    data = {"logging": {"log_dir": str(log_dir), "platforms": {"system": "system.log"}}}
+    with open(cfg_path, "w") as f:
+        json.dump(data, f)
+
+    cfg = JSONConfig(cfg_path)
+    log_cfg = LogConfig(log_dir=cfg.logging.log_dir, platforms=cfg.logging.platforms)
+    manager = LogManager(log_cfg)
+    manager.info("system", "hello")
+
+    log_file = log_dir / "system.log"
+    assert log_file.exists()


### PR DESCRIPTION
## Summary
- implement `JSONConfig` for attribute-style access to JSON configuration
- export the loader in `social.utils`
- test configuration access and integration with `LogManager`

## Testing
- `pytest tests/social/test_json_config.py -v --tb=short`
- `python run_tests.py tests/social/test_json_config.py`

------
https://chatgpt.com/codex/tasks/task_e_6840795b5b708329ada6695d9f759e6f