### PR TITLE
Add docs for new modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ For a quick reference of the repository layout, see [docs/directory_overview.md]
 - Social media integration
 - UI automation and interaction
 - Trading bot integration
+- Stealth browser automation for low-detection web tasks
+- Dreamscribe narrative memory system
 
 ## Repository Structure
 
@@ -842,12 +844,14 @@ Dream.OS/
 - [Autonomous Operations](docs/onboarding/02_autonomous_operations.md)
 - [System Integration](docs/onboarding/03_system_integration.md)
 - [Advanced Topics](docs/onboarding/04_advanced_topics.md)
+- [Architecture Overview](docs/architecture_overview.md)
 - [Content Loop Framework](docs/onboarding/05_content_loop.md)
 
 ### 2. Development
 - [Code Style Guide](docs/code_style_guide.md)
 - [Testing Guide](docs/testing_guide.md)
 - [Project Setup](docs/project_setup_guide.md)
+- [User Guide](docs/user_guide.md)
 - [Contribution Guide](docs/contribution_guide.md)
 
 ### 3. API Reference
@@ -855,6 +859,8 @@ Dream.OS/
 - [Agent API](docs/api/agents.md)
 - [Messaging API](docs/api/messaging.md)
 - [Trading API](docs/api/trading.md)
+- [StealthBrowser API](docs/api/stealth_browser.md)
+- [Dreamscribe API](docs/api/dreamscribe.md)
 
 ## Features
 

--- a/docs/api/dreamscribe.md
+++ b/docs/api/dreamscribe.md
@@ -1,0 +1,25 @@
+# Dreamscribe API
+
+`Dreamscribe` lives under `dreamos/core/dreamscribe.py` and provides the narrative memory system used by Dream.OS.
+
+## Purpose
+Dreamscribe ingests devlogs and system events, turning them into **memory fragments** that can be connected into narrative threads. It tracks insights and patterns to give the system historical context.
+
+## Main Classes
+- **MemoryFragment** – dataclass representing a single memory item.
+- **NarrativeThread** – dataclass linking related memories together.
+- **Dreamscribe** – orchestrates loading, updating and querying the memory corpus.
+
+## Example
+```python
+from dreamos.core.dreamscribe import Dreamscribe
+
+scribe = Dreamscribe()
+memory_id = scribe.ingest_devlog({
+    "agent_id": "agent_1",
+    "content": "Task completed successfully",
+})
+info = scribe.get_system_insights()
+```
+
+Memory files are stored under `runtime/` so make sure those directories exist before running.

--- a/docs/api/stealth_browser.md
+++ b/docs/api/stealth_browser.md
@@ -1,0 +1,25 @@
+# StealthBrowser API
+
+This document provides a brief reference for the `StealthBrowser` module located under `agent_tools/general_tools/browser`.
+
+## Overview
+The `StealthBrowser` wraps an undetected Chromium instance with helper classes for automated web interaction. It manages login flows, cookie persistence and provides helper methods for sending messages to Codex or other platforms while avoiding detection.
+
+## Key Classes
+- **StealthBrowser** - main controller for launching and managing the browser session.
+- **LoginHandler** - performs multi step login and message input.
+- **CookieManager** - loads and saves session cookies.
+- **StealthBrowserBridge** - integrates the browser with Dream.OS messaging via a request queue.
+
+## Basic Usage
+```python
+from agent_tools.general_tools.browser import StealthBrowser, DEFAULT_CONFIG
+
+browser = StealthBrowser(DEFAULT_CONFIG)
+browser.start()
+browser.navigate_to("https://example.com")
+# interact via browser.login_handler
+browser.stop()
+```
+
+For integration into the orchestration system see `agent_tools/general_tools/browser/integration.py`.

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -1,0 +1,19 @@
+# System Architecture Overview
+
+This document summarizes the high level architecture of Dream.OS.
+
+## Core Layers
+1. **System Orchestrator** – coordinates all agents and services.
+2. **Messaging Layer** – provides the `CellPhone` and `CaptainPhone` channels with history tracking.
+3. **Task Manager** – assigns and monitors tasks across agents.
+4. **Logging/Devlog** – central log manager with optional Discord mirroring.
+5. **Extensions** – modules such as StealthBrowser and Dreamscribe extend core capabilities.
+
+```
+Agent <-> CellPhone <-> UnifiedMessageSystem <-> Agent
+                     ^
+                     |
+                  Captain
+```
+
+External services (Discord, trading APIs, web automation) plug into the orchestrator via adapters. Dreamscribe stores narrative memory under `runtime/`, while StealthBrowser enables low-detection browser automation for the ChatGPT and Codex bridges.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,0 +1,30 @@
+# Dream.OS User Guide
+
+This guide provides a quick introduction for new users.
+
+## Starting the System
+1. Clone the repository and install dependencies as described in [project_setup_guide.md](project_setup_guide.md).
+2. Prepare the runtime directories:
+   ```bash
+   mkdir -p runtime/agent_comms/governance
+   mkdir -p runtime/agent_comms/onboarding
+   mkdir -p runtime/bridge_inbox
+   ```
+3. Copy environment examples from `discord_bot/.env.example` and any trading modules, then edit with your credentials.
+4. Run the orchestrator and Discord bot:
+   ```bash
+   python dreamos/main.py
+   python -m discord_bot.bot
+   ```
+
+## Common Commands
+Use the Discord bot to manage agents:
+- `!list` – list running agents
+- `!resume <id>` – resume an agent
+- `!verify <id>` – verify agent state
+- `!broadcast <msg>` – send a message to all agents
+
+## Further Reading
+- [System Architecture Overview](architecture_overview.md)
+- [StealthBrowser API](api/stealth_browser.md)
+- [Dreamscribe API](api/dreamscribe.md)


### PR DESCRIPTION
## Summary
- document StealthBrowser and Dreamscribe APIs
- add system architecture overview and quick user guide
- update README with new docs and features

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6840b9e3e2f88329bbf982d33aaa6021