### PR TITLE
Implement captain role

### DIFF
--- a/dreamos/core/agent_control/__init__.py
+++ b/dreamos/core/agent_control/__init__.py
@@ -7,5 +7,6 @@ Provides coordinate transformation and agent control functionality.
 from .coordinate_transformer import CoordinateTransformer
 from .agent_control import AgentControl
 from .ui_automation import UIAutomation
+from .captain import Captain
 
-__all__ = ['CoordinateTransformer', 'AgentControl', 'UIAutomation']
+__all__ = ['CoordinateTransformer', 'AgentControl', 'UIAutomation', 'Captain']

--- a/dreamos/core/agent_control/captain.py
+++ b/dreamos/core/agent_control/captain.py
@@ -1,0 +1,81 @@
+import logging
+from typing import Optional, Dict, Any, List
+
+from ..messaging.unified_message_system import MessageSystem, MessageMode, MessagePriority
+from ..messaging.common import Message
+from ..messaging.enums import TaskPriority, TaskStatus
+from .task_manager import TaskManager
+
+
+class Captain:
+    """Central coordinator for agents.
+
+    The Captain assigns tasks and routes messages using the
+    :class:`MessageSystem`. It also keeps track of tasks via
+    :class:`TaskManager`.
+    """
+
+    def __init__(self, ums: Optional[MessageSystem] = None, task_manager: Optional[TaskManager] = None):
+        self.ums = ums or MessageSystem()
+        self.task_manager = task_manager or TaskManager()
+        self.logger = logging.getLogger("dreamos.captain")
+
+    async def assign_task(
+        self,
+        agent_id: str,
+        name: str,
+        description: str,
+        priority: TaskPriority = TaskPriority.NORMAL,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """Create a task for ``agent_id`` and notify them.
+
+        Returns the created task id or ``None`` on failure.
+        """
+        try:
+            task = self.task_manager.create_task(
+                name=name,
+                description=description,
+                agent_id=agent_id,
+                priority=priority,
+                metadata=metadata or {},
+            )
+
+            await self.ums.send(
+                to_agent=agent_id,
+                content=description,
+                mode=MessageMode.TASK,
+                priority=MessagePriority(min(priority.value, len(MessagePriority) - 1)),
+                from_agent="captain",
+                metadata={"task_id": task.task_id},
+            )
+            return task.task_id
+        except Exception as exc:  # pragma: no cover - log unexpected errors
+            self.logger.error("Failed to assign task to %s: %s", agent_id, exc)
+            return None
+
+    async def prioritize_tasks(self) -> List[Dict[str, Any]]:
+        """Return all tasks sorted by priority (highest first)."""
+        try:
+            tasks = sorted(
+                self.task_manager._tasks.values(),
+                key=lambda t: t.priority.value,
+                reverse=True,
+            )
+            return [t.to_dict() for t in tasks]
+        except Exception as exc:  # pragma: no cover - log unexpected errors
+            self.logger.error("Failed to gather tasks: %s", exc)
+            return []
+
+    async def handle_message(self, message: Message) -> None:
+        """Process a message directed to the captain."""
+        try:
+            if message.content.startswith("task_complete:"):
+                _, task_id = message.content.split(":", 1)
+                self.task_manager.update_task_status(task_id, TaskStatus.COMPLETED)
+        except Exception as exc:  # pragma: no cover - log unexpected errors
+            self.logger.error(
+                "Error processing response from %s: %s", message.from_agent, exc
+            )
+
+

--- a/tests/agent_control/test_captain.py
+++ b/tests/agent_control/test_captain.py
@@ -1,0 +1,60 @@
+import asyncio
+from pathlib import Path
+import importlib.util
+import importlib
+import sys
+import types
+
+import pytest
+
+# Dynamically load Captain without importing heavy optional deps
+CAPTAIN_PATH = Path(__file__).resolve().parents[2] / "dreamos" / "core" / "agent_control" / "captain.py"
+core_stub = types.ModuleType("dreamos.core")
+core_stub.__path__ = [str(CAPTAIN_PATH.parent.parent)]
+agent_control_stub = types.ModuleType("dreamos.core.agent_control")
+agent_control_stub.__path__ = [str(CAPTAIN_PATH.parent)]
+sys.modules.setdefault("dreamos.core", core_stub)
+sys.modules.setdefault("dreamos.core.agent_control", agent_control_stub)
+
+spec = importlib.util.spec_from_file_location(
+    "dreamos.core.agent_control.captain", CAPTAIN_PATH
+)
+captain_module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = captain_module
+spec.loader.exec_module(captain_module)
+Captain = captain_module.Captain
+MessageSystem = importlib.import_module('dreamos.core.messaging.unified_message_system').MessageSystem
+MessageMode = importlib.import_module('dreamos.core.messaging.enums').MessageMode
+TaskPriority = importlib.import_module('dreamos.core.messaging.enums').TaskPriority
+
+
+@pytest.mark.asyncio
+async def test_assign_task_sends_message(tmp_path):
+    ums = MessageSystem(runtime_dir=tmp_path)
+    captain = Captain(ums=ums)
+
+    task_id = await captain.assign_task(
+        agent_id="agent1",
+        name="demo",
+        description="do something",
+        priority=TaskPriority.HIGH,
+    )
+
+    assert task_id is not None
+
+    messages = await ums.receive("agent1")
+    assert len(messages) == 1
+    msg = messages[0]
+    assert msg.mode == MessageMode.TASK
+    assert msg.metadata["task_id"] == task_id
+
+
+@pytest.mark.asyncio
+async def test_prioritize_tasks(tmp_path):
+    ums = MessageSystem(runtime_dir=tmp_path)
+    captain = Captain(ums=ums)
+
+    await captain.assign_task("a1", "t1", "d1", TaskPriority.MEDIUM)
+    await captain.assign_task("a2", "t2", "d2", TaskPriority.CRITICAL)
+    ordered = await captain.prioritize_tasks()
+    assert ordered[0]["priority"] == "CRITICAL"

--- a/tests/agent_control/test_devlog_manager.py
+++ b/tests/agent_control/test_devlog_manager.py
@@ -50,10 +50,10 @@ sys.modules.setdefault("aiohttp", types.ModuleType("aiohttp"))
 cell_phone_stub = types.ModuleType("dreamos.core.messaging.cell_phone")
 cell_phone_stub.CaptainPhone = type("CaptainPhone", (), {"__init__": lambda *_, **__: None})
 cell_phone_stub.CellPhone = type("CellPhone", (), {"__init__": lambda *_, **__: None})
-sys.modules.setdefault("dreamos.core.messaging.cell_phone", cell_phone_stub)
+sys.modules["dreamos.core.messaging.cell_phone"] = cell_phone_stub
 captain_phone_stub = types.ModuleType("dreamos.core.messaging.captain_phone")
 captain_phone_stub.CaptainPhone = type("CaptainPhone", (), {"__init__": lambda *_, **__: None})
-sys.modules.setdefault("dreamos.core.messaging.captain_phone", captain_phone_stub)
+sys.modules["dreamos.core.messaging.captain_phone"] = captain_phone_stub
 message_stub = types.ModuleType("dreamos.core.messaging.message")
 message_stub.Message = object
 sys.modules.setdefault("dreamos.core.messaging.message", message_stub)


### PR DESCRIPTION
## Summary
- create a `Captain` class for coordinating agents and handling tasks
- expose `Captain` in agent_control package
- update DevLog manager test stubs
- add unit tests for the Captain role

## Testing
- `python run_tests.py tests/agent_control/test_captain.py`
- `python run_tests.py tests`

------
https://chatgpt.com/codex/tasks/task_e_6840b9c286f483298ffa7032e3ee99ed