### PR TITLE
Document skip reasons in error analysis

### DIFF
--- a/test_error_analysis.json
+++ b/test_error_analysis.json
@@ -1,9 +1,9 @@
 {
   "test_status": {
-    "total_tests": 74,
-    "passed_tests": 7,
+    "total_tests": 81,
+    "passed_tests": 16,
     "failed_tests": 0,
-    "quarantined_tests": 67
+    "quarantined_tests": 65
   },
   "test_details": {
     "test_log_rotation": {
@@ -197,6 +197,18 @@
       "requires_architectural_changes": true
     }
   },
+  "skipped_tests": [
+    {
+      "file": "tests/social/strategies/test_strategy_base.py",
+      "reason": "Strategic bypass - Strategy base refactor pending",
+      "count": 48
+    },
+    {
+      "file": "tests/social/strategies/test_reddit_strategy.py",
+      "reason": "Strategic bypass - Reddit strategy refactor pending",
+      "count": 17
+    }
+  ],
   "agent_assignments": {
     "Agent-1": {
       "assigned_tests": [],


### PR DESCRIPTION
## Summary
- update counts in `test_error_analysis.json`
- list skipped strategy tests and explain why

## Testing
- `pytest -q`
- `python run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_6841c9b4ae2483299c1fe4af3e4a0ffb