### PR TITLE
Add Discord UI and voice mocks

### DIFF
--- a/tests/utils/mock_discord/__init__.py
+++ b/tests/utils/mock_discord/__init__.py
@@ -8,7 +8,34 @@ from . import discord
 from . import helpers
 from . import models
 from . import webhook
+from . import ui
+from . import voice
 from .models import MockGuild, MockRole, MockChannel, MockMember, MockMessage, MockEmbed, MockWebhook, MockFile
+from .ui import View, Button, Select
+from .voice import (
+    VoiceClient,
+    Gateway,
+    Opus,
+    OpusLoader,
+    VoiceState,
+    VoiceProtocol,
+    VoiceRegion,
+    VoiceRecv,
+    VoiceSend,
+    VoiceUtils,
+    VoiceWebSocket,
+    VoiceWebSocketClient,
+    VoiceWebSocketServer,
+    VoiceWebSocketUtils,
+    VoiceWebSocketVoice,
+    VoiceWebSocketVoiceClient,
+    VoiceWebSocketVoiceServer,
+    VoiceWebSocketVoiceUtils,
+    VoiceWebSocketVoiceWebSocket,
+    VoiceWebSocketVoiceWebSocketClient,
+    VoiceWebSocketVoiceWebSocketServer,
+    VoiceWebSocketVoiceWebSocketUtils,
+)
 
 __all__ = [
     'base',
@@ -18,6 +45,8 @@ __all__ = [
     'helpers',
     'models',
     'webhook',
+    'ui',
+    'voice',
     'MockGuild',
     'MockRole',
     'MockChannel',
@@ -26,4 +55,29 @@ __all__ = [
     'MockEmbed',
     'MockWebhook',
     'MockFile',
+    'View',
+    'Button',
+    'Select',
+    'VoiceClient',
+    'Gateway',
+    'Opus',
+    'OpusLoader',
+    'VoiceState',
+    'VoiceProtocol',
+    'VoiceRegion',
+    'VoiceRecv',
+    'VoiceSend',
+    'VoiceUtils',
+    'VoiceWebSocket',
+    'VoiceWebSocketClient',
+    'VoiceWebSocketServer',
+    'VoiceWebSocketUtils',
+    'VoiceWebSocketVoice',
+    'VoiceWebSocketVoiceClient',
+    'VoiceWebSocketVoiceServer',
+    'VoiceWebSocketVoiceUtils',
+    'VoiceWebSocketVoiceWebSocket',
+    'VoiceWebSocketVoiceWebSocketClient',
+    'VoiceWebSocketVoiceWebSocketServer',
+    'VoiceWebSocketVoiceWebSocketUtils',
 ]

--- a/tests/utils/mock_discord/ui.py
+++ b/tests/utils/mock_discord/ui.py
@@ -1,0 +1,24 @@
+"""Mock Discord UI components for testing."""
+from typing import Any, List, Optional
+
+class View:
+    """Simplified mock of ``discord.ui.View``."""
+    def __init__(self, *items: Any):
+        self.children = list(items)
+
+    def add_item(self, item: Any) -> None:
+        self.children.append(item)
+
+class Button:
+    """Simplified mock of ``discord.ui.Button``."""
+    def __init__(self, label: str = "", style: int = 0, **kwargs: Any):
+        self.label = label
+        self.style = style
+        self.kwargs = kwargs
+
+class Select:
+    """Simplified mock of ``discord.ui.Select``."""
+    def __init__(self, placeholder: str = "", options: Optional[List[Any]] = None, **kwargs: Any):
+        self.placeholder = placeholder
+        self.options = options or []
+        self.kwargs = kwargs

--- a/tests/utils/mock_discord/voice.py
+++ b/tests/utils/mock_discord/voice.py
@@ -1,0 +1,33 @@
+"""Mock Discord voice-related classes."""
+class VoiceClient:
+    """Simplified mock of ``discord.VoiceClient``."""
+    async def connect(self, *args, **kwargs):
+        pass
+    async def disconnect(self, *args, **kwargs):
+        pass
+    async def play(self, *args, **kwargs):
+        pass
+    def stop(self, *args, **kwargs):
+        pass
+
+class Gateway: pass
+class Opus: pass
+class OpusLoader: pass
+class VoiceState: pass
+class VoiceProtocol: pass
+class VoiceRegion: pass
+class VoiceRecv: pass
+class VoiceSend: pass
+class VoiceUtils: pass
+class VoiceWebSocket: pass
+class VoiceWebSocketClient: pass
+class VoiceWebSocketServer: pass
+class VoiceWebSocketUtils: pass
+class VoiceWebSocketVoice: pass
+class VoiceWebSocketVoiceClient: pass
+class VoiceWebSocketVoiceServer: pass
+class VoiceWebSocketVoiceUtils: pass
+class VoiceWebSocketVoiceWebSocket: pass
+class VoiceWebSocketVoiceWebSocketClient: pass
+class VoiceWebSocketVoiceWebSocketServer: pass
+class VoiceWebSocketVoiceWebSocketUtils: pass


### PR DESCRIPTION
## Summary
- add missing Discord mock classes for ui and voice modules
- expose new mocks via tests/utils/mock_discord package

## Testing
- `pytest -q`
- `python run_tests.py` *(fails: MessageHandler.send_message() got an unexpected keyword argument 'metadata')*

------
https://chatgpt.com/codex/tasks/task_e_684453d6e5288329bab5f885199631e3