### PR TITLE
Add missing test prompt file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,8 @@ episodes/
 messages/
 templates/
 runtime/
+!runtime/test_prompts/
+!runtime/test_prompts/TEST_AND_DEBUG_AUTONOMY.yaml
 test_logs/
 test_config/
 test_data/

--- a/runtime/test_prompts/TEST_AND_DEBUG_AUTONOMY.yaml
+++ b/runtime/test_prompts/TEST_AND_DEBUG_AUTONOMY.yaml
@@ -1,0 +1,4 @@
+# Sample prompts for overnight testing of autonomy features
+prompts:
+  - "Run the autonomy unit test suite and report results"
+  - "Analyze recent failures and attempt automatic fixes"


### PR DESCRIPTION
## Summary
- add `runtime/test_prompts/TEST_AND_DEBUG_AUTONOMY.yaml`
- unignore test prompt files so git tracks them

## Testing
- `python run_tests.py` *(fails: MessageHandler.send_message() got an unexpected keyword argument 'metadata')*

------
https://chatgpt.com/codex/tasks/task_e_6844738c512c832988c012f0913dc175