### PR TITLE
Add initial GPT router module

### DIFF
--- a/dreamos/core/gpt_router/bridge_logger.py
+++ b/dreamos/core/gpt_router/bridge_logger.py
@@ -1,0 +1,21 @@
+"""
+Bridge Logger
+-------------
+Logs prompt and response pairs with metadata.
+"""
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+class BridgeLogger:
+    """Simple JSON line logger."""
+
+    def __init__(self, log_path: Path | str = "runtime/bridge_log.jsonl"):
+        self.log_path = Path(log_path)
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def log(self, record: Dict[str, Any]):
+        with open(self.log_path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record) + "\n")

--- a/dreamos/core/gpt_router/navigator.py
+++ b/dreamos/core/gpt_router/navigator.py
@@ -1,0 +1,20 @@
+"""
+Conversation Navigator
+---------------------
+Iterates through conversation URLs from a list or API source.
+"""
+
+from typing import Iterable, Iterator
+
+
+class ConversationNavigator:
+    """Cycle through conversation URLs."""
+
+    def __init__(self, urls: Iterable[str]):
+        self._urls = iter(urls)
+
+    def __iter__(self) -> Iterator[str]:
+        return self
+
+    def __next__(self) -> str:
+        return next(self._urls)

--- a/dreamos/core/gpt_router/profiles/codexpert.yaml
+++ b/dreamos/core/gpt_router/profiles/codexpert.yaml
@@ -1,0 +1,2 @@
+prompt: "Please extract and annotate the code."
+gpt_profile: "CodeXpert"

--- a/dreamos/core/gpt_router/profiles/default.yaml
+++ b/dreamos/core/gpt_router/profiles/default.yaml
@@ -1,0 +1,2 @@
+prompt: "Give a detailed reflection on this conversation."
+gpt_profile: "DefaultGPT"

--- a/dreamos/core/gpt_router/profiles/summarizer.yaml
+++ b/dreamos/core/gpt_router/profiles/summarizer.yaml
@@ -1,0 +1,2 @@
+prompt: "Summarize this exchange in bullet points."
+gpt_profile: "Summarizer-GPT"

--- a/dreamos/core/gpt_router/prompt_engine.py
+++ b/dreamos/core/gpt_router/prompt_engine.py
@@ -1,0 +1,42 @@
+"""
+ChatGPT Prompt Engine
+---------------------
+Coordinates scraping, routing and optional Codex validation.
+"""
+
+import time
+from typing import Dict
+
+from .prompt_router import PromptRouter
+
+
+class ChatGPTPromptEngine:
+    """Orchestrates prompt delivery and response collection."""
+
+    def __init__(self, scraper, codex=None):
+        self.scraper = scraper
+        self.validator = codex
+        self.router = PromptRouter()
+
+    def process_conversation(self, convo_url: str) -> Dict[str, str]:
+        self.scraper.driver.get(convo_url)
+        time.sleep(2)
+
+        routing = self.router.decide_prompt(convo_url)
+        prompt = routing["prompt"]
+        target_gpt = routing["gpt_profile"]
+
+        self.scraper.switch_to_gpt(target_gpt)
+        self.scraper.send_prompt(prompt)
+
+        reply = self.scraper.extract_latest_reply(wait_for_completion=True)
+
+        validated = self.validator.validate(reply) if self.validator else True
+
+        return {
+            "url": convo_url,
+            "prompt": prompt,
+            "reply": reply,
+            "gpt": target_gpt,
+            "validated": validated,
+        }

--- a/dreamos/core/gpt_router/prompt_router.py
+++ b/dreamos/core/gpt_router/prompt_router.py
@@ -1,0 +1,30 @@
+"""
+Prompt Router
+-------------
+Selects the appropriate prompt and GPT profile based on conversation context.
+"""
+
+import yaml
+from pathlib import Path
+from typing import Dict
+
+
+class PromptRouter:
+    """Decide which prompt and GPT profile to use."""
+
+    def __init__(self, profiles_dir: Path | str = Path(__file__).parent / "profiles"):
+        self.profiles_dir = Path(profiles_dir)
+
+    def _load_profile(self, name: str) -> Dict[str, str]:
+        path = self.profiles_dir / f"{name}.yaml"
+        with open(path, "r", encoding="utf-8") as fh:
+            return yaml.safe_load(fh)
+
+    def decide_prompt(self, convo_url: str) -> Dict[str, str]:
+        if "code" in convo_url:
+            profile = self._load_profile("codexpert")
+        elif "summary" in convo_url:
+            profile = self._load_profile("summarizer")
+        else:
+            profile = self._load_profile("default")
+        return profile

--- a/dreamos/core/gpt_router/tasks.yaml
+++ b/dreamos/core/gpt_router/tasks.yaml
@@ -1,0 +1,7 @@
+# Maintenance tasks for gpt_router module
+- id: update-prompts
+  desc: Update prompt profiles and routing rules when new GPT variants arrive
+- id: validate-routing
+  desc: Ensure PromptRouter selects correct profile based on URL patterns
+- id: log-review
+  desc: Periodically review bridge logs for anomalies

--- a/dreamos/core/gpt_router/validator.py
+++ b/dreamos/core/gpt_router/validator.py
@@ -1,0 +1,36 @@
+"""
+Codex Validator
+---------------
+Validates responses using a Codex-style LLM.
+"""
+
+from typing import Any
+import logging
+import os
+
+import openai
+
+logger = logging.getLogger(__name__)
+
+
+class CodexValidator:
+    """Check responses for hallucinations and format errors."""
+
+    def __init__(self, model: str = "gpt-4o"):
+        self.model = model
+        self.api_key = os.environ.get("OPENAI_API_KEY")
+
+    def validate(self, text: str) -> bool:
+        if not self.api_key:
+            logger.warning("OPENAI_API_KEY not set; skipping validation")
+            return True
+        try:
+            response = openai.ChatCompletion.create(
+                model=self.model,
+                messages=[{"role": "user", "content": f"Validate: {text}"}],
+            )
+            verdict = response.choices[0].message.content.strip().lower()
+            return "fail" not in verdict
+        except Exception as exc:
+            logger.error("Validation error: %s", exc)
+            return False

--- a/tests/gpt_router/test_prompt_router.py
+++ b/tests/gpt_router/test_prompt_router.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+from dreamos.core.gpt_router.prompt_router import PromptRouter
+
+
+def test_decide_prompt_tmp(tmp_path):
+    profiles = tmp_path / "profiles"
+    profiles.mkdir()
+    (profiles / "default.yaml").write_text("prompt: d\ngpt_profile: base")
+    router = PromptRouter(profiles_dir=profiles)
+    result = router.decide_prompt("http://example.com")
+    assert result["prompt"] == "d"
+    assert result["gpt_profile"] == "base"


### PR DESCRIPTION
## Summary
- scaffold `gpt_router` package with conversation navigator, router and prompt engine
- include Codex validator and bridge logger utilities
- add default routing profiles and maintenance tasks
- provide test stub for the prompt router

## Testing
- `python run_tests.py` *(fails: file not found)*
- `pytest tests/gpt_router/test_prompt_router.py -q` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_68457c00afc08329825d12b5bad5854c