### PR TITLE
Improve training references

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,6 +848,7 @@ Dream.OS/
 - [Advanced Topics](docs/onboarding/04_advanced_topics.md)
 - [Architecture Overview](docs/architecture_overview.md)
 - [Content Loop Framework](docs/onboarding/05_content_loop.md)
+- [Training Overview](docs/onboarding/06_training_overview.md)
 
 ### 2. Development
 - [Code Style Guide](docs/code_style_guide.md)

--- a/docs/directory_overview.md
+++ b/docs/directory_overview.md
@@ -5,7 +5,8 @@ This document describes the purpose of the main folders in the repository to mak
 ## Core Components
 
 - `dreamos/` - Core system implementation including orchestrator, messaging, agent management, and self-discovery modules.
-- `tools/` - All utility scripts, automation tools, and helper functions for development and operations.
+- `tools/` - Utility scripts, automation helpers, and other development tools.
+- `agent_tools/` - Agent utilities including mailbox management and onboarding resources.
 - `discord_bot/` - Discord integration including the bot and command handlers.
 - `crime_report_generator/` - Stand‑alone module used for generating crime reports.
 
@@ -13,6 +14,7 @@ This document describes the purpose of the main folders in the repository to mak
 
 - `docs/` - Project documentation and guides.
 - `docs/examples/` - Code samples and examples demonstrating library usage.
+- `agent_tools/mailbox/onboarding/training/` - Comprehensive training materials and skill library.
 
 ## Configuration and Data
 

--- a/docs/onboarding/00_agent_onboarding.md
+++ b/docs/onboarding/00_agent_onboarding.md
@@ -87,6 +87,8 @@ D:\SWARM\Dream.OS\
 2. Initialize your core systems
 3. Explore the system architecture
 4. Begin autonomous task processing
+5. Review the training resources in `agent_tools/mailbox/onboarding/training`
+   and the [Training Overview](06_training_overview.md)
 
 ## ⚠️ Duplication Prevention
 - This guide is the single source of truth

--- a/docs/onboarding/06_training_overview.md
+++ b/docs/onboarding/06_training_overview.md
@@ -1,0 +1,34 @@
+# Training Overview
+
+> **Reference Protocol**: This document extends the [Master Onboarding Guide](00_agent_onboarding.md)
+> **Version**: 1.0.0
+> **Last Updated**: 2024-06-09
+
+This overview explains where to find training material for Dream.OS agents and how to use it to build your skills.
+
+## Training Directory
+
+All training resources live under `agent_tools/mailbox/onboarding/training/`. The folder contains:
+
+- `core/` – fundamental Dream.OS concepts and principles
+- `tools/` – tutorials for Cursor, Codex and other tools
+- `best_practices/` – guidelines for security, testing and documentation
+- `advanced/` – in-depth topics for experienced agents
+- `skill_library/` – templates for documenting learned skills
+- `stubborn_issues/` – solutions to complex problems worth remembering
+
+See `agent_tools/mailbox/onboarding/training/README.md` for full details.
+
+## Using the Training Materials
+
+1. Start with the core training to learn system basics.
+2. Work through the tool tutorials while experimenting in your environment.
+3. Refer to best practices whenever you write code or documentation.
+4. Explore advanced topics as your responsibilities grow.
+5. Contribute new skills and document stubborn issues you solve.
+
+## Next Steps
+
+Return to the [Agent Core Guide](01_agent_core.md) after reviewing this overview and keep the training directory handy as you work.
+
+"Knowledge sharing strengthens the swarm."


### PR DESCRIPTION
## Summary
- reference new training docs in the root README
- list `agent_tools` and training materials in the directory overview
- mention training directory in the main onboarding guide
- add a `Training Overview` doc

## Testing
- `python run_tests.py` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68457d0aa21c832984c577b8645d7fc1