### PR TITLE
Consolidate parsing helpers

### DIFF
--- a/dreamos/core/autonomy/base/runner_core.py
+++ b/dreamos/core/autonomy/base/runner_core.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Dict, List, Any, Optional, Set, Protocol, TypeVar, Generic
 
 from ..logging.log_manager import LogManager
+from ...utils.testing_utils import parse_test_failures as parse_failures
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -190,28 +191,5 @@ class RunnerCore(Generic[T]):
             }
     
     def parse_test_failures(self, output: str) -> Dict[str, str]:
-        """Parse test failures from pytest output.
-        
-        Args:
-            output: Pytest output string
-            
-        Returns:
-            Dictionary mapping test names to error messages
-        """
-        failures = {}
-        current_test = None
-        error_lines = []
-        
-        for line in output.split("\n"):
-            if line.startswith("FAILED"):
-                if current_test:
-                    failures[current_test] = "\n".join(error_lines)
-                current_test = line.split("::")[-1].strip()
-                error_lines = []
-            elif current_test and line.strip():
-                error_lines.append(line)
-        
-        if current_test:
-            failures[current_test] = "\n".join(error_lines)
-        
-        return failures 
+        """Parse test failures from pytest output."""
+        return parse_failures(output)

--- a/dreamos/core/autonomy/test_debug/utils/debug_utils.py
+++ b/dreamos/core/autonomy/test_debug/utils/debug_utils.py
@@ -28,35 +28,9 @@ logger = logging.getLogger(__name__)
 
 class TestDebugUtils:
     """Shared utilities for test debugging."""
-    
-    @staticmethod
-    def parse_test_failures(test_output: str) -> Dict[str, str]:
-        """Parse test failures from test output.
-        
-        Args:
-            test_output: Raw test output string
-            
-        Returns:
-            Dictionary mapping test names to error messages
-        """
-        failures = {}
-        current_test = None
-        error_lines = []
-        
-        for line in test_output.splitlines():
-            if line.startswith("FAILED "):
-                # Extract test name
-                test_name = line.split("FAILED ")[1].strip()
-                current_test = test_name
-                error_lines = []
-            elif current_test and line.strip():
-                error_lines.append(line)
-                if line.startswith("AssertionError") or line.startswith("Error"):
-                    failures[current_test] = "\n".join(error_lines)
-                    current_test = None
-                    error_lines = []
-        
-        return failures
+
+    from dreamos.core.utils.testing_utils import parse_test_failures as _parse_failures
+    parse_test_failures = staticmethod(_parse_failures)
     
     @staticmethod
     def create_fix_request(

--- a/dreamos/core/utils/__init__.py
+++ b/dreamos/core/utils/__init__.py
@@ -24,6 +24,7 @@ from . import region_finder
 from . import retry
 from . import safe_io
 from . import serialization
+from . import testing_utils
 from . import system_ops
 from . import yaml_utils
 
@@ -49,6 +50,7 @@ __all__ = [
     'retry',
     'safe_io',
     'serialization',
+    'testing_utils',
     'system_ops',
     'yaml_utils',
 ]

--- a/dreamos/core/utils/testing_utils.py
+++ b/dreamos/core/utils/testing_utils.py
@@ -1,0 +1,30 @@
+from typing import Dict
+
+
+def parse_test_failures(output: str) -> Dict[str, str]:
+    """Parse pytest output and return a mapping of test names to errors."""
+    failures: Dict[str, str] = {}
+    current_test = None
+    error_lines = []
+
+    for line in output.splitlines():
+        if line.startswith("FAILED"):
+            if current_test:
+                failures[current_test] = "\n".join(error_lines)
+            parts = line.split()
+            if len(parts) >= 2:
+                current_test = parts[1].split("::")[-1]
+            else:
+                current_test = line.split("::")[-1].strip()
+            error_lines = []
+        elif current_test and line.strip():
+            error_lines.append(line)
+            if line.startswith("AssertionError") or line.startswith("Error"):
+                failures[current_test] = "\n".join(error_lines)
+                current_test = None
+                error_lines = []
+
+    if current_test:
+        failures[current_test] = "\n".join(error_lines)
+
+    return failures


### PR DESCRIPTION
## Summary
- centralize test failure parsing logic
- reuse the new helper in `RunnerCore` and debug utilities

## Testing
- `python scripts/run_tests.py` *(fails: ImportError while loading conftest)*

------
https://chatgpt.com/codex/tasks/task_e_684aba0701048329889bd9010308937b