### PR TITLE
Add spin-off docs and prompt generator

### DIFF
--- a/docs/examples/self_healing_swarm/README.md
+++ b/docs/examples/self_healing_swarm/README.md
@@ -1,0 +1,5 @@
+# Self-Healing Swarm Template
+
+This minimal example demonstrates how to launch a small Dream.OS swarm with automatic recovery enabled. The `start_swarm.py` script boots a default agent controller and enables periodic restart logic.
+
+Use this template as a starting point for integrating Dream.OS into your Cursor projects or other environments.

--- a/docs/examples/self_healing_swarm/start_swarm.py
+++ b/docs/examples/self_healing_swarm/start_swarm.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Example starter for a self-healing Dream.OS swarm."""
+
+from dreamos.core.agent.control.agent_controller import AgentController
+
+
+def main() -> None:
+    controller = AgentController()
+    controller.resume_all(auto_heal=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/product_offerings.md
+++ b/docs/product_offerings.md
@@ -1,0 +1,38 @@
+# Dream.OS Product Offerings
+
+This page outlines optional packages built on top of Dream.OS. These micro projects help teams quickly integrate core features without adopting the entire platform.
+
+## Self-Healing Agent Swarm Starter Template
+
+A lightweight starter project aimed at engineering teams who use the Cursor environment. It ships with:
+
+- Preconfigured agent orchestration using Dream.OS messaging loops.
+- Automatic detection and restart of stalled agents.
+- Example configuration files for deploying a small swarm in Cursor.
+
+### Quick Start
+
+1. Install Dream.OS following the [Setup Guide](setup.md).
+2. Copy the starter template from `docs/examples/self_healing_swarm/`.
+3. Run `python start_swarm.py` to launch the default agents.
+
+This template provides a minimal, self-healing swarm that companies can extend with their own agents and tasks.
+
+## Auto-Prompt Script Generator for Multi-Agent Systems
+
+A command line tool that converts a YAML description of agent prompts into an executable Python script. The generated script uses `ChatGPTBridge` to send prompts to the LLM and can be plugged into existing workflows.
+
+### Key Features
+
+- Supports multiple agent roles with distinct system and user prompts.
+- Produces a ready-to-run Python script using Dream.OS bridge utilities.
+- Ideal for quickly testing new agent interactions or batch prompt workflows.
+
+### Usage
+
+```bash
+python tools/auto_prompt_script_generator.py prompts.yaml out_script.py
+python out_script.py  # executes the generated prompts
+```
+
+These spin-offs demonstrate how Dream.OS can be packaged into bite-sized tools that organizations can adopt incrementally.

--- a/tools/auto_prompt_script_generator.py
+++ b/tools/auto_prompt_script_generator.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Auto-Prompt Script Generator
+-----------------------------
+Create runnable prompt scripts for multi-agent workflows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import textwrap
+from pathlib import Path
+from typing import Dict, List
+
+import yaml
+
+
+TEMPLATE = textwrap.dedent(
+    """
+    import asyncio
+    from dreamos.core.bridge.chatgpt.bridge import ChatGPTBridge
+
+    async def main() -> None:
+        async with ChatGPTBridge() as bridge:
+    {agent_sections}
+            print("All prompts executed")
+
+    if __name__ == "__main__":
+        asyncio.run(main())
+    """
+)
+
+
+def _format_section(system: str, user: str) -> str:
+    system_line = f"{{'role': 'system', 'content': {system!r}}}"
+    user_line = f"{{'role': 'user', 'content': {user!r}}}"
+    return "\n".join(
+        [
+            "            await bridge.chat([",
+            f"                {system_line},",
+            f"                {user_line}
+            ], max_tokens=200)",
+        ]
+    )
+
+
+def generate_script(config: Path, output: Path) -> None:
+    data: Dict[str, List[Dict[str, str]]] = yaml.safe_load(config.read_text())
+    sections: List[str] = []
+    for agent in data.get("agents", []):
+        system_prompt = agent.get("system_prompt", "")
+        user_prompt = agent.get("user_prompt", "")
+        sections.append(_format_section(system_prompt, user_prompt))
+    script = TEMPLATE.format(agent_sections="\n".join(sections))
+    output.write_text(script)
+    print(f"Generated script written to {output}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate prompt script from YAML config")
+    parser.add_argument("config", type=Path, help="YAML file describing agent prompts")
+    parser.add_argument("output", type=Path, help="Path for generated Python script")
+    args = parser.parse_args()
+    generate_script(args.config, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document new product spin-offs including a self-healing swarm starter and an auto‑prompt generator
- add example self-healing swarm starter template under docs/examples
- implement `auto_prompt_script_generator.py` to create runnable prompt scripts from YAML

## Testing
- `python scripts/run_tests.py --category unit` *(fails: ModuleNotFoundError: No module named 'tests.utils.test_environment')*

------
https://chatgpt.com/codex/tasks/task_e_6853fe6fc6dc83299134b21519b05cc8