### PR TITLE
Implement Dreamscribe query and beta sprint plan

### DIFF
--- a/docs/project/sprint_plan.md
+++ b/docs/project/sprint_plan.md
@@ -1,0 +1,33 @@
+# Beta Sprint Plan
+
+This sprint focuses on achieving Beta readiness by completing outstanding items from the PRD and roadmap.
+
+## Objectives
+- Finalize containerization, metrics dashboard and security hardening.
+- Expand the Dreamscribe lore system with ingestion and query APIs.
+- Lay groundwork for community deployment and persistent code loops.
+- Ensure full test coverage and integration validation.
+
+## Task Breakdown
+
+| ID | Phase | Objective | Status |
+| --- | --- | --- | --- |
+| VALIDATE-CONTAINER-BUILD-004 | Scalability & Hardening | Validate Docker builds across all agents | pending |
+| COMPLETE-GRAFANA-DASHBOARD-005 | Scalability & Hardening | Finalize Grafana dashboard for metrics endpoint | pending |
+| INGEST-DEVLOG-FAILURES-006 | Lore Creation & Memory Ecosystem | Import devlogs and failures via Dreamscribe | pending |
+| LORE-QUERY-API-007 | Lore Creation & Memory Ecosystem | Implement query interface to surface lore | pending |
+| LOCAL-INSTANCE-DEPLOYMENT-008 | Self-Growing Community Platform | Enable users to deploy Dream.OS locally or via Discord | pending |
+| PERSISTENT-LOOPS-009 | Self-Growing Community Platform | Add persistent loops for code evolution and testing | pending |
+| EXTENSION-HOOKS-010 | Self-Growing Community Platform | Provide extension hooks for broad domain usage | pending |
+| BETA-TEST-SUITE-011 | Testing & Quality | Run full test suite and validate new features | pending |
+
+Each task corresponds to an entry in `dreamos/tasks/phase_plan_tasks.yaml` so agents can coordinate work using the YAML file.
+
+## Testing
+Run the standard suite before closing the sprint:
+
+```bash
+python run_tests.py
+```
+
+All new features must include unit tests and pass continuous integration checks.

--- a/dreamos/core/ai/dreamscribe.py
+++ b/dreamos/core/ai/dreamscribe.py
@@ -305,4 +305,30 @@ class Dreamscribe:
                 for thread_id, memories in self.threads.items()
             ],
             "patterns": self.insight_patterns
-        } 
+        }
+
+    # ------------------------------------------------------------------
+    # New Beta API ------------------------------------------------------
+    # ------------------------------------------------------------------
+    def query_memories(
+        self,
+        agent_id: Optional[str] = None,
+        start: Optional[float] = None,
+        end: Optional[float] = None,
+        keyword: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return memory fragments filtered by agent, time range, and keyword."""
+
+        results = []
+        for frag in self.memory_corpus.values():
+            if agent_id and frag.get("agent_id") != agent_id:
+                continue
+            if start and frag.get("timestamp", 0) < start:
+                continue
+            if end and frag.get("timestamp", 0) > end:
+                continue
+            if keyword and keyword.lower() not in frag.get("content", "").lower():
+                continue
+            results.append(frag)
+
+        return results

--- a/dreamos/tasks/phase_plan_tasks.yaml
+++ b/dreamos/tasks/phase_plan_tasks.yaml
@@ -40,3 +40,45 @@
   phase: Scalability & Hardening
   objective: Implement file permission lockdowns and sandboxing
   status: active
+
+# Beta Readiness Sprint
+- task: VALIDATE-CONTAINER-BUILD-004
+  assigned_to: agent-4
+  phase: Scalability & Hardening
+  objective: Validate Docker builds across all agents
+  status: pending
+- task: COMPLETE-GRAFANA-DASHBOARD-005
+  assigned_to: agent-6
+  phase: Scalability & Hardening
+  objective: Finalize Grafana dashboard for metrics endpoint
+  status: pending
+- task: INGEST-DEVLOG-FAILURES-006
+  assigned_to: agent-7
+  phase: Lore Creation & Memory Ecosystem
+  objective: Import devlogs and failures via Dreamscribe
+  status: pending
+- task: LORE-QUERY-API-007
+  assigned_to: agent-7
+  phase: Lore Creation & Memory Ecosystem
+  objective: Implement query interface to surface lore
+  status: pending
+- task: LOCAL-INSTANCE-DEPLOYMENT-008
+  assigned_to: agent-2
+  phase: Self-Growing Community Platform
+  objective: Enable users to deploy Dream.OS locally or via Discord
+  status: pending
+- task: PERSISTENT-LOOPS-009
+  assigned_to: agent-5
+  phase: Self-Growing Community Platform
+  objective: Add persistent loops for code evolution and testing
+  status: pending
+- task: EXTENSION-HOOKS-010
+  assigned_to: agent-4
+  phase: Self-Growing Community Platform
+  objective: Provide extension hooks for broad domain usage
+  status: pending
+- task: BETA-TEST-SUITE-011
+  assigned_to: qa-agent
+  phase: Testing & Quality
+  objective: Run full test suite and validate new features
+  status: pending

--- a/tests/core/ai/test_dreamscribe.py
+++ b/tests/core/ai/test_dreamscribe.py
@@ -1,0 +1,23 @@
+from dreamos.core.ai import dreamscribe as ds_mod
+
+
+def _patch_paths(tmp_path, monkeypatch):
+    monkeypatch.setattr(ds_mod, "MEMORY_CORPUS_PATH", tmp_path / "memory.json")
+    monkeypatch.setattr(ds_mod, "NARRATIVE_THREADS_PATH", tmp_path / "threads")
+    monkeypatch.setattr(ds_mod, "INSIGHT_PATTERNS_PATH", tmp_path / "patterns.json")
+
+
+def test_query_memories_filters(monkeypatch, tmp_path):
+    _patch_paths(tmp_path, monkeypatch)
+    scribe = ds_mod.Dreamscribe()
+
+    scribe.ingest_devlog({"agent_id": "a1", "content": "task complete"})
+    scribe.ingest_devlog({"agent_id": "a2", "content": "failure occurred"})
+
+    res = scribe.query_memories(agent_id="a1")
+    assert len(res) == 1
+    assert res[0]["agent_id"] == "a1"
+
+    res = scribe.query_memories(keyword="failure")
+    assert len(res) == 1
+    assert res[0]["agent_id"] == "a2"


### PR DESCRIPTION
## Summary
- add `query_memories` API to `Dreamscribe`
- outline Beta sprint plan with tasks
- expand `phase_plan_tasks.yaml` with Beta Readiness Sprint
- add unit test covering new query API

## Testing
- `pip install -r requirements-test.txt`
- `pip install pyyaml`
- `python run_tests.py` *(fails: ModuleNotFoundError: No module named 'dreamos.core.ui')*

------
https://chatgpt.com/codex/tasks/task_e_685ec80b885883298c4024337ff6fb8a