### PR TITLE
Implement lore ingestion and query utilities

### DIFF
--- a/docs/core/dreamscribe.md
+++ b/docs/core/dreamscribe.md
@@ -90,4 +90,13 @@ Make sure these directories exist before running Dreamscribe.
 4. **Resource Management**
    - Clean up old memories
    - Archive inactive threads
-   - Monitor storage usage 
+   - Monitor storage usage
+
+## CLI Tools
+
+Dreamscribe includes simple command line utilities located in the `tools/` directory.
+
+- `python -m tools.devlog.ingest_devlogs` ingests all `runtime/devlog/agents/*/devlog.md`
+  files into the lore database.
+- `python tools/query_lore.py --agent agent_1 --keyword error` queries stored memories
+  with optional filters.

--- a/tests/tools/__init__.py
+++ b/tests/tools/__init__.py
@@ -1,0 +1,8 @@
+# AUTO-GENERATED __init__.py
+# DO NOT EDIT MANUALLY - changes may be overwritten
+
+from . import test_ingest_devlogs
+
+__all__ = [
+    'test_ingest_devlogs',
+]

--- a/tests/tools/test_ingest_devlogs.py
+++ b/tests/tools/test_ingest_devlogs.py
@@ -1,0 +1,24 @@
+import json
+from pathlib import Path
+from dreamos.core.ai import dreamscribe as ds_mod
+from tools.devlog.ingest_devlogs import ingest_agent_devlog
+
+
+def _patch_paths(tmp_path, monkeypatch):
+    monkeypatch.setattr(ds_mod, "MEMORY_CORPUS_PATH", tmp_path / "memory.json")
+    monkeypatch.setattr(ds_mod, "NARRATIVE_THREADS_PATH", tmp_path / "threads")
+    monkeypatch.setattr(ds_mod, "INSIGHT_PATTERNS_PATH", tmp_path / "patterns.json")
+
+
+def test_ingest_agent_devlog(monkeypatch, tmp_path):
+    _patch_paths(tmp_path, monkeypatch)
+    scribe = ds_mod.Dreamscribe()
+    devlog_dir = tmp_path / "agent1"
+    devlog_dir.mkdir()
+    devlog_file = devlog_dir / "devlog.md"
+    devlog_file.write_text("## Task 1\nDid something\n## Task 2\nAnother thing")
+
+    ids = ingest_agent_devlog("agent1", devlog_file, scribe)
+    assert len(ids) == 2
+    mem = scribe.get_memory(ids[0])
+    assert mem["agent_id"] == "agent1"

--- a/tools/devlog/__init__.py
+++ b/tools/devlog/__init__.py
@@ -2,7 +2,9 @@
 # DO NOT EDIT MANUALLY - changes may be overwritten
 
 from . import devlog_pitcher
+from . import ingest_devlogs
 
 __all__ = [
     'devlog_pitcher',
+    'ingest_devlogs',
 ]

--- a/tools/devlog/ingest_devlogs.py
+++ b/tools/devlog/ingest_devlogs.py
@@ -1,0 +1,76 @@
+import argparse
+from pathlib import Path
+from typing import List, Dict
+
+from dreamos.core.ai.dreamscribe import Dreamscribe
+from .devlog_pitcher import parse_devlog
+
+
+def ingest_agent_devlog(agent_id: str, devlog_path: Path, scribe: Dreamscribe) -> List[str]:
+    """Ingest all entries from a single devlog file.
+
+    Parameters
+    ----------
+    agent_id: str
+        Identifier for the agent the devlog belongs to.
+    devlog_path: Path
+        Path to the devlog markdown file.
+    scribe: Dreamscribe
+        Dreamscribe instance used to store lore.
+
+    Returns
+    -------
+    List[str]
+        IDs of ingested memory fragments.
+    """
+    entries = parse_devlog(devlog_path)
+    memory_ids: List[str] = []
+    for entry in entries:
+        memory_id = scribe.ingest_devlog({
+            "agent_id": agent_id,
+            "content": entry.get("content", ""),
+            "context": {"heading": entry.get("heading", "")},
+        })
+        memory_ids.append(memory_id)
+    return memory_ids
+
+
+def ingest_all_devlogs(root: Path, scribe: Dreamscribe) -> Dict[str, List[str]]:
+    """Ingest devlogs for all agents found under *root*.
+
+    Parameters
+    ----------
+    root: Path
+        Directory containing ``agent*/devlog.md`` files.
+    scribe: Dreamscribe
+        Dreamscribe instance used to store lore.
+
+    Returns
+    -------
+    Dict[str, List[str]]
+        Mapping of agent_id to list of ingested memory IDs.
+    """
+    result: Dict[str, List[str]] = {}
+    for devlog in root.glob("agent*/devlog.md"):
+        agent_id = devlog.parent.name
+        result[agent_id] = ingest_agent_devlog(agent_id, devlog, scribe)
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Ingest devlog entries into Dreamscribe lore")
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path("runtime/devlog/agents"),
+        help="Root directory containing agent devlogs",
+    )
+    args = parser.parse_args()
+
+    scribe = Dreamscribe()
+    ingest_all_devlogs(args.root, scribe)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tools/query_lore.py
+++ b/tools/query_lore.py
@@ -1,0 +1,33 @@
+import argparse
+from typing import Optional
+from pathlib import Path
+
+from dreamos.core.ai.dreamscribe import Dreamscribe
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Query Dreamscribe lore")
+    parser.add_argument("--agent", help="Filter by agent ID")
+    parser.add_argument("--start", type=float, help="Filter by start timestamp")
+    parser.add_argument("--end", type=float, help="Filter by end timestamp")
+    parser.add_argument("--keyword", help="Filter by keyword")
+    args = parser.parse_args()
+
+    scribe = Dreamscribe()
+    memories = scribe.query_memories(
+        agent_id=args.agent,
+        start=args.start,
+        end=args.end,
+        keyword=args.keyword,
+    )
+
+    for mem in memories:
+        ts = mem.get("timestamp")
+        agent = mem.get("agent_id")
+        content = mem.get("content", "")
+        print(f"{ts} | {agent}: {content}")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add CLI for ingesting devlog files into Dreamscribe
- add lore querying utility
- document CLI usage in dreamscribe docs
- test devlog ingestion helper

## Testing
- `python run_tests.py` *(fails: ModuleNotFoundError: No module named 'dreamos.core.ui')*


------
https://chatgpt.com/codex/tasks/task_e_686a60cd57288329a7ff3e4efbb02677